### PR TITLE
"weigh" the install docs content

### DIFF
--- a/content/en/docs/install/azure-kubernetes-service.md
+++ b/content/en/docs/install/azure-kubernetes-service.md
@@ -4,6 +4,7 @@ description: In this tutorial you'll learn how to deploy SpinKube on Azure Kuber
 date: 2024-02-16
 categories: [Spin Operator]
 tags: [Tutorials]
+weight: 5
 aliases:
   - /docs/spin-operator/tutorials/deploy-on-azure-kubernetes-service
 ---

--- a/content/en/docs/install/compatibility-matrices.md
+++ b/content/en/docs/install/compatibility-matrices.md
@@ -4,6 +4,7 @@ description: A set of compatibility matrices for each SpinKube executor
 date: 2024-11-08
 categories: [Spin Operator]
 tags: [reference]
+weight: 99
 ---
 
 ## `containerd-shim-spin` Executor

--- a/content/en/docs/install/installing-with-helm.md
+++ b/content/en/docs/install/installing-with-helm.md
@@ -3,6 +3,7 @@ title: Installing with Helm
 description: This guide walks you through the process of installing SpinKube using [Helm](https://helm.sh).
 date: 2024-02-16
 tags: [Installation]
+weight: 4
 aliases:
   - /docs/spin-operator/installation/installing-with-helm
 ---

--- a/content/en/docs/install/linode-kubernetes-engine.md
+++ b/content/en/docs/install/linode-kubernetes-engine.md
@@ -3,6 +3,7 @@ title: Installing on Linode Kubernetes Engine (LKE)
 description: This guide walks you through the process of installing SpinKube on [LKE](https://www.linode.com/docs/products/compute/kubernetes/).
 date: 2024-07-23
 tags: [Installation]
+weight: 6
 ---
 
 This guide walks through the process of installing and configuring SpinKube on Linode Kubernetes

--- a/content/en/docs/install/microk8s.md
+++ b/content/en/docs/install/microk8s.md
@@ -3,6 +3,7 @@ title: Installing on Microk8s
 description: This guide walks you through the process of installing SpinKube using [Microk8s](https://microk8s.io/).
 date: 2024-06-19
 tags: [Installation]
+weight: 8
 ---
 
 This guide walks through the process of installing and configuring Microk8s and SpinKube.

--- a/content/en/docs/install/rancher-desktop.md
+++ b/content/en/docs/install/rancher-desktop.md
@@ -4,6 +4,7 @@ description: This tutorial shows how to integrate SpinKube and Rancher Desktop.
 date: 2024-02-16
 categories: [Spin Operator]
 tags: [Tutorials]
+weight: 7
 aliases:
 - /docs/spin-operator/tutorials/integrating-with-rancher-desktop
 ---

--- a/content/en/docs/install/spin-kube-plugin.md
+++ b/content/en/docs/install/spin-kube-plugin.md
@@ -3,6 +3,7 @@ title: Installing the `spin kube` plugin
 description: Learn how to install the `kube` plugin.
 categories: [guides]
 tags: [plugins, kubernetes, spin]
+weight: 3
 aliases:
 - /docs/spin-plugin-kube/installation
 ---


### PR DESCRIPTION
This organizes the installation guides into roughly four categories:

1. generic installs (quickstart, plugin, helm)
2. production installs (azure, LKE)
3. local machine installs (rancher, microk8s)
4. supporting material (compatibility matrix)

Old:

![image](https://github.com/user-attachments/assets/8bea249e-48ed-4bb2-a781-4cf4a8dbe4b2)

New: 

![image](https://github.com/user-attachments/assets/96abb143-c32b-45b7-a61f-eea904e52e50)
